### PR TITLE
Remove apps-common/client/legacy/date-controls in favour of one taken from eregistrations project.

### DIFF
--- a/apps-common/client/legacy/date-controls.js
+++ b/apps-common/client/legacy/date-controls.js
@@ -1,6 +1,0 @@
-'use strict';
-
-var dateControls = require('mano-legacy/live/date-controls');
-
-dateControls.order = ['d', 'm', 'y'];
-dateControls.labels = { year: 'AAAA', month: 'MM', day: 'DD' };


### PR DESCRIPTION
Connected to https://github.com/egovernment/eregistrations/issues/977.
